### PR TITLE
Phase 5: Edge Function cleanup — Zod validation, GoTrue lookup, shared helpers

### DIFF
--- a/supabase/functions/_shared/validators.ts
+++ b/supabase/functions/_shared/validators.ts
@@ -1,0 +1,45 @@
+import { z } from 'npm:zod@3';
+
+// Schemas duplicated from packages/validators/src/invite.ts (Option 1: inline for Deno)
+export const InviteMemberSchema = z.object({
+  organization_id: z.string().uuid(),
+  email: z.string().email(),
+  role: z.enum(['manager']),
+});
+
+export const InviteTenantSchema = z.object({
+  lease_id: z.string().uuid(),
+  email: z.string().email(),
+  is_primary: z.boolean().default(false),
+});
+
+export const AcceptInviteSchema = z.object({
+  token: z.string().min(1),
+});
+
+export const CreateConnectAccountSchema = z.object({
+  organization_id: z.string().uuid(),
+});
+
+export const CreateAccountLinkSchema = z.object({
+  organization_id: z.string().uuid(),
+  return_url: z.string().url(),
+  refresh_url: z.string().url(),
+});
+
+export type InviteMemberInput = z.infer<typeof InviteMemberSchema>;
+export type InviteTenantInput = z.infer<typeof InviteTenantSchema>;
+export type AcceptInviteInput = z.infer<typeof AcceptInviteSchema>;
+export type CreateConnectAccountInput = z.infer<typeof CreateConnectAccountSchema>;
+export type CreateAccountLinkInput = z.infer<typeof CreateAccountLinkSchema>;
+
+export function validate<T>(
+  schema: z.ZodSchema<T>,
+  data: unknown,
+): { success: true; data: T } | { success: false; error: string } {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    return { success: false, error: result.error.issues.map((i) => i.message).join(', ') };
+  }
+  return { success: true, data: result.data };
+}

--- a/supabase/functions/accept-invite/index.ts
+++ b/supabase/functions/accept-invite/index.ts
@@ -2,17 +2,16 @@ import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { corsResponse, jsonResponse, errorResponse, methodNotAllowed } from '../_shared/cors.ts';
 import { getAuthenticatedUser, getServiceClient } from '../_shared/auth.ts';
 import { verifyInviteToken } from '../_shared/invite-token.ts';
+import { validate, AcceptInviteSchema } from '../_shared/validators.ts';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return corsResponse(req);
   if (req.method !== 'POST') return methodNotAllowed();
 
   try {
-    const { token } = await req.json();
-
-    if (!token) {
-      return errorResponse(req, 'token is required', 400);
-    }
+    const parsed = validate(AcceptInviteSchema, await req.json());
+    if (!parsed.success) return errorResponse(req, parsed.error, 400);
+    const { token } = parsed.data;
 
     // Verify invite token
     const payload = await verifyInviteToken(token);

--- a/supabase/functions/create-account-link/index.ts
+++ b/supabase/functions/create-account-link/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import Stripe from 'https://esm.sh/stripe@14?target=deno';
 import { corsResponse, jsonResponse, errorResponse, methodNotAllowed } from '../_shared/cors.ts';
 import { getAuthenticatedUser, requireOrgOwner, getServiceClient } from '../_shared/auth.ts';
+import { validate, CreateAccountLinkSchema } from '../_shared/validators.ts';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return corsResponse(req);
@@ -11,10 +12,9 @@ serve(async (req) => {
     const user = await getAuthenticatedUser(req);
     if (!user) return errorResponse(req, 'Unauthorized', 401);
 
-    const { organization_id, return_url, refresh_url } = await req.json();
-    if (!organization_id || !return_url || !refresh_url) {
-      return errorResponse(req, 'organization_id, return_url, and refresh_url are required', 400);
-    }
+    const parsed = validate(CreateAccountLinkSchema, await req.json());
+    if (!parsed.success) return errorResponse(req, parsed.error, 400);
+    const { organization_id, return_url, refresh_url } = parsed.data;
 
     const isOwner = await requireOrgOwner(user.id, organization_id);
     if (!isOwner) return errorResponse(req, 'Forbidden', 403);

--- a/supabase/functions/create-connect-account/index.ts
+++ b/supabase/functions/create-connect-account/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import Stripe from 'https://esm.sh/stripe@14?target=deno';
 import { corsResponse, jsonResponse, errorResponse, methodNotAllowed } from '../_shared/cors.ts';
 import { getAuthenticatedUser, requireOrgOwner, getServiceClient } from '../_shared/auth.ts';
+import { validate, CreateConnectAccountSchema } from '../_shared/validators.ts';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return corsResponse(req);
@@ -11,8 +12,9 @@ serve(async (req) => {
     const user = await getAuthenticatedUser(req);
     if (!user) return errorResponse(req, 'Unauthorized', 401);
 
-    const { organization_id } = await req.json();
-    if (!organization_id) return errorResponse(req, 'organization_id is required', 400);
+    const parsed = validate(CreateConnectAccountSchema, await req.json());
+    if (!parsed.success) return errorResponse(req, parsed.error, 400);
+    const { organization_id } = parsed.data;
 
     const isOwner = await requireOrgOwner(user.id, organization_id);
     if (!isOwner) return errorResponse(req, 'Forbidden', 403);

--- a/supabase/functions/create-payment-intent/index.ts
+++ b/supabase/functions/create-payment-intent/index.ts
@@ -1,52 +1,31 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import Stripe from 'https://esm.sh/stripe@14?target=deno';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { corsResponse, jsonResponse, errorResponse, methodNotAllowed } from '../_shared/cors.ts';
+import { getAuthenticatedUser, getServiceClient } from '../_shared/auth.ts';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
+    return corsResponse(req);
   }
 
   if (req.method !== 'POST') {
-    return new Response('Method Not Allowed', { status: 405, headers: { 'Allow': 'POST, OPTIONS' } });
+    return methodNotAllowed();
   }
 
   try {
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL')!,
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
-    );
-
     // 1. Authenticate user
-    const jwt = req.headers.get('Authorization')?.replace('Bearer ', '');
-    if (!jwt) {
-      return new Response(JSON.stringify({ error: 'Missing authorization' }), {
-        status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
-    }
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser(jwt);
-    if (authError || !user) {
-      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-        status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+    const user = await getAuthenticatedUser(req);
+    if (!user) {
+      return errorResponse(req, 'Unauthorized', 401);
     }
 
     const { lease_id, rent_charge_id, amount_cents } = await req.json();
 
     if (!lease_id || !amount_cents || !Number.isInteger(amount_cents) || amount_cents <= 0) {
-      return new Response(JSON.stringify({ error: 'lease_id and a positive integer amount_cents are required' }), {
-        status: 400,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      return errorResponse(req, 'lease_id and a positive integer amount_cents are required', 400);
     }
+
+    const supabase = getServiceClient();
 
     // 2. Verify user is an active tenant on this lease
     const { data: tenantCheck } = await supabase
@@ -58,10 +37,7 @@ serve(async (req) => {
       .single();
 
     if (!tenantCheck) {
-      return new Response(JSON.stringify({ error: 'Forbidden' }), {
-        status: 403,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      return errorResponse(req, 'Forbidden', 403);
     }
 
     // 3. Fetch landlord's Stripe Connect account
@@ -86,10 +62,7 @@ serve(async (req) => {
       ?.units?.properties?.organizations?.stripe_accounts?.[0]?.stripe_account_id;
 
     if (!stripeAccountId) {
-      return new Response(JSON.stringify({ error: 'Landlord not set up for payments' }), {
-        status: 422,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      return errorResponse(req, 'Landlord not set up for payments', 422);
     }
 
     // 4. Create Stripe PaymentIntent
@@ -120,14 +93,8 @@ serve(async (req) => {
       stripe_payment_intent_id: intent.id,
     });
 
-    return new Response(
-      JSON.stringify({ client_secret: intent.client_secret }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-    );
+    return jsonResponse(req, { client_secret: intent.client_secret });
   } catch (err) {
-    return new Response(JSON.stringify({ error: (err as Error).message }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    return errorResponse(req, (err as Error).message, 500);
   }
 });

--- a/supabase/functions/generate-late-fees/index.ts
+++ b/supabase/functions/generate-late-fees/index.ts
@@ -1,5 +1,5 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { getServiceClient } from '../_shared/auth.ts';
 
 serve(async (req) => {
   if (req.method !== 'POST') {
@@ -14,10 +14,7 @@ serve(async (req) => {
   }
 
   try {
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL')!,
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
-    );
+    const supabase = getServiceClient();
 
     const { data, error } = await supabase.rpc('generate_late_fees');
 

--- a/supabase/functions/invite-member/index.ts
+++ b/supabase/functions/invite-member/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { corsResponse, jsonResponse, errorResponse, methodNotAllowed } from '../_shared/cors.ts';
 import { getAuthenticatedUser, requireOrgOwner, getServiceClient } from '../_shared/auth.ts';
 import { signInviteToken } from '../_shared/invite-token.ts';
+import { validate, InviteMemberSchema } from '../_shared/validators.ts';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return corsResponse(req);
@@ -11,11 +12,9 @@ serve(async (req) => {
     const user = await getAuthenticatedUser(req);
     if (!user) return errorResponse(req, 'Unauthorized', 401);
 
-    const { organization_id, email, role } = await req.json();
-
-    if (!organization_id || !email || role !== 'manager') {
-      return errorResponse(req, 'organization_id, email, and role (must be "manager") are required', 400);
-    }
+    const parsed = validate(InviteMemberSchema, await req.json());
+    if (!parsed.success) return errorResponse(req, parsed.error, 400);
+    const { organization_id, email, role } = parsed.data;
 
     // Verify caller is owner
     const isOwner = await requireOrgOwner(user.id, organization_id);
@@ -28,10 +27,19 @@ serve(async (req) => {
     const { data: invited, error: inviteError } = await supabase.auth.admin.inviteUserByEmail(email);
 
     if (inviteError) {
-      // User likely already exists — look up by email via paginated search
-      const { data: { users } } = await supabase.auth.admin.listUsers({ perPage: 1000 });
-      const existingUser = users?.find((u) => u.email === email);
-      if (!existingUser) {
+      // User likely already exists — look up by email directly via GoTrue Admin API
+      const lookupRes = await fetch(
+        `${Deno.env.get('SUPABASE_URL')}/auth/v1/admin/users?filter=${encodeURIComponent(email)}&per_page=1`,
+        {
+          headers: {
+            Authorization: `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')}`,
+            apikey: Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+          },
+        },
+      );
+      const lookupData = await lookupRes.json();
+      const existingUser = lookupData?.users?.[0];
+      if (!existingUser || existingUser.email !== email) {
         return errorResponse(req, inviteError.message || 'Failed to invite user', 500);
       }
       inviteeId = existingUser.id;

--- a/supabase/functions/invite-tenant/index.ts
+++ b/supabase/functions/invite-tenant/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { corsResponse, jsonResponse, errorResponse, methodNotAllowed } from '../_shared/cors.ts';
 import { getAuthenticatedUser, requireOrgMember, getServiceClient } from '../_shared/auth.ts';
 import { signInviteToken } from '../_shared/invite-token.ts';
+import { validate, InviteTenantSchema } from '../_shared/validators.ts';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return corsResponse(req);
@@ -11,11 +12,9 @@ serve(async (req) => {
     const user = await getAuthenticatedUser(req);
     if (!user) return errorResponse(req, 'Unauthorized', 401);
 
-    const { lease_id, email, is_primary } = await req.json();
-
-    if (!lease_id || !email) {
-      return errorResponse(req, 'lease_id and email are required', 400);
-    }
+    const parsed = validate(InviteTenantSchema, await req.json());
+    if (!parsed.success) return errorResponse(req, parsed.error, 400);
+    const { lease_id, email, is_primary } = parsed.data;
 
     const supabase = getServiceClient();
 
@@ -39,10 +38,19 @@ serve(async (req) => {
     const { data: invited, error: inviteError } = await supabase.auth.admin.inviteUserByEmail(email);
 
     if (inviteError) {
-      // User likely already exists — look up by email via paginated search
-      const { data: { users } } = await supabase.auth.admin.listUsers({ perPage: 1000 });
-      const existingUser = users?.find((u) => u.email === email);
-      if (!existingUser) {
+      // User likely already exists — look up by email directly via GoTrue Admin API
+      const lookupRes = await fetch(
+        `${Deno.env.get('SUPABASE_URL')}/auth/v1/admin/users?filter=${encodeURIComponent(email)}&per_page=1`,
+        {
+          headers: {
+            Authorization: `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')}`,
+            apikey: Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+          },
+        },
+      );
+      const lookupData = await lookupRes.json();
+      const existingUser = lookupData?.users?.[0];
+      if (!existingUser || existingUser.email !== email) {
         return errorResponse(req, inviteError.message || 'Failed to invite user', 500);
       }
       inviteeId = existingUser.id;
@@ -68,7 +76,7 @@ serve(async (req) => {
       .insert({
         lease_id,
         user_id: inviteeId,
-        is_primary: is_primary ?? false,
+        is_primary,
       })
       .select('id')
       .single();

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,6 +1,6 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import Stripe from 'https://esm.sh/stripe@14?target=deno';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { getServiceClient } from '../_shared/auth.ts';
 
 serve(async (req) => {
   if (req.method !== 'POST') {
@@ -30,10 +30,7 @@ serve(async (req) => {
       return new Response('Bad signature', { status: 400 });
     }
 
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL')!,
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
-    );
+    const supabase = getServiceClient();
 
     switch (event.type) {
       case 'payment_intent.succeeded': {


### PR DESCRIPTION
## Summary
- **#28** — Refactored `create-payment-intent`, `generate-late-fees`, and `stripe-webhook` to use shared `getServiceClient()`, `getAuthenticatedUser()`, and CORS helpers instead of inline `createClient`/`corsHeaders`
- **#23** — Added `_shared/validators.ts` with Zod schemas (`npm:zod@3` for Deno) and wired validation into 5 Edge Functions (`accept-invite`, `invite-member`, `invite-tenant`, `create-connect-account`, `create-account-link`)
- **#24** — Replaced `listUsers({ perPage: 1000 })` with direct GoTrue Admin API lookup (`GET /auth/v1/admin/users?filter=<email>&per_page=1`) in `invite-member` and `invite-tenant`
- **#29** — `@propnest/test-utils` already exists with all required RLS helpers (created in a prior phase)

Closes #23, closes #24, closes #28, closes #29

## Test plan
- [x] `pnpm turbo typecheck` — all 6 packages pass
- [x] `pnpm turbo test:unit` — 12 tests pass (mocks), no regressions
- [ ] Manual: verify Edge Functions deploy and respond correctly in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)