### PR TITLE
Phase 6: Property & Lease Management UI

### DIFF
--- a/apps/web/src/app/(dashboard)/properties/[id]/add-unit-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/add-unit-dialog.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { PlusIcon } from 'lucide-react';
+
+export function AddUnitDialog({ propertyId }: { propertyId: string }) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const formData = new FormData(e.currentTarget);
+
+    const { error: insertError } = await supabase.from('units').insert({
+      property_id: propertyId,
+      unit_number: (formData.get('unit_number') as string) || null,
+      bedrooms: formData.get('bedrooms')
+        ? Number(formData.get('bedrooms'))
+        : null,
+      bathrooms: formData.get('bathrooms')
+        ? Number(formData.get('bathrooms'))
+        : null,
+      square_feet: formData.get('square_feet')
+        ? Number(formData.get('square_feet'))
+        : null,
+      rent_amount: formData.get('rent_amount')
+        ? Number(formData.get('rent_amount'))
+        : null,
+      notes: (formData.get('notes') as string) || null,
+    });
+
+    if (insertError) {
+      setError(insertError.message);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(false);
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button />}>
+        <PlusIcon className="size-4" />
+        Add Unit
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add Unit</DialogTitle>
+          <DialogDescription>
+            Add a new unit to this property.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="unit_number">Unit Number</Label>
+            <Input
+              id="unit_number"
+              name="unit_number"
+              placeholder="e.g. 101, A1"
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="bedrooms">Bedrooms</Label>
+              <Input
+                id="bedrooms"
+                name="bedrooms"
+                type="number"
+                step="0.5"
+                min="0"
+                placeholder="e.g. 2"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="bathrooms">Bathrooms</Label>
+              <Input
+                id="bathrooms"
+                name="bathrooms"
+                type="number"
+                step="0.5"
+                min="0"
+                placeholder="e.g. 1.5"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="square_feet">Square Feet</Label>
+              <Input
+                id="square_feet"
+                name="square_feet"
+                type="number"
+                min="0"
+                placeholder="e.g. 850"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rent_amount">Rent Amount</Label>
+              <Input
+                id="rent_amount"
+                name="rent_amount"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 1500.00"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes</Label>
+            <Textarea
+              id="notes"
+              name="notes"
+              placeholder="Additional notes about this unit"
+              rows={3}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Adding...' : 'Add Unit'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(dashboard)/properties/[id]/create-lease-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/create-lease-dialog.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Plus, X } from 'lucide-react';
+
+interface Unit {
+  id: string;
+  unit_number: string | null;
+  rent_amount: number | null;
+}
+
+interface CreateLeaseDialogProps {
+  propertyId: string;
+  units: Unit[];
+  activeLeaseUnitIds: Set<string>;
+}
+
+export function CreateLeaseDialog({
+  propertyId,
+  units,
+  activeLeaseUnitIds,
+}: CreateLeaseDialogProps) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [unitId, setUnitId] = useState<string | null>(null);
+  const [lateFeeType, setLateFeeType] = useState<string>('flat');
+  const [tenantEmails, setTenantEmails] = useState<string[]>(['']);
+
+  const availableUnits = units.filter((u) => !activeLeaseUnitIds.has(u.id));
+
+  function resetForm() {
+    setUnitId(null);
+    setLateFeeType('flat');
+    setTenantEmails(['']);
+    setError(null);
+  }
+
+  function addTenantEmail() {
+    setTenantEmails((prev) => [...prev, '']);
+  }
+
+  function removeTenantEmail(index: number) {
+    if (tenantEmails.length <= 1) return;
+    setTenantEmails((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function updateTenantEmail(index: number, value: string) {
+    setTenantEmails((prev) => prev.map((e, i) => (i === index ? value : e)));
+  }
+
+  function formatCurrency(amount: number | null) {
+    if (amount == null) return '';
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(amount);
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const formData = new FormData(e.currentTarget);
+
+    if (!unitId) {
+      setError('Please select a unit.');
+      setLoading(false);
+      return;
+    }
+
+    const rentAmount = parseFloat(formData.get('rent_amount') as string);
+    const securityDeposit = formData.get('security_deposit') as string;
+    const startDate = formData.get('start_date') as string;
+    const endDate = formData.get('end_date') as string;
+    const rentDueDay = parseInt(formData.get('rent_due_day') as string, 10);
+    const gracePeriodDays = parseInt(
+      formData.get('grace_period_days') as string,
+      10
+    );
+    const lateFeeAmount = formData.get('late_fee_amount') as string;
+
+    // 1. Insert lease
+    const { data: lease, error: leaseError } = await supabase
+      .from('leases')
+      .insert({
+        unit_id: unitId,
+        status: 'draft' as const,
+        rent_amount: rentAmount,
+        security_deposit: securityDeposit ? parseFloat(securityDeposit) : null,
+        start_date: startDate,
+        end_date: endDate || null,
+        rent_due_day: rentDueDay,
+        grace_period_days: gracePeriodDays,
+        late_fee_type: lateFeeType,
+        late_fee_amount: lateFeeAmount ? parseFloat(lateFeeAmount) : null,
+      })
+      .select('id')
+      .single();
+
+    if (leaseError) {
+      setError(leaseError.message);
+      setLoading(false);
+      return;
+    }
+
+    // 2. Invite tenants
+    const validEmails = tenantEmails.filter((email) => email.trim() !== '');
+    const failedInvites: string[] = [];
+
+    if (validEmails.length > 0) {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      for (let i = 0; i < validEmails.length; i++) {
+        const email = validEmails[i].trim();
+        try {
+          const res = await fetch(
+            `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/invite-tenant`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${session?.access_token}`,
+              },
+              body: JSON.stringify({
+                lease_id: lease.id,
+                email,
+                is_primary: i === 0,
+              }),
+            }
+          );
+
+          if (!res.ok) {
+            const body = await res.json().catch(() => null);
+            const msg = body?.error || res.statusText;
+            failedInvites.push(`${email}: ${msg}`);
+          }
+        } catch (err) {
+          failedInvites.push(
+            `${email}: ${err instanceof Error ? err.message : 'Unknown error'}`
+          );
+        }
+      }
+    }
+
+    setLoading(false);
+
+    if (failedInvites.length > 0) {
+      setError(
+        `Lease created but tenant invite failed for ${failedInvites.join('; ')}`
+      );
+      // Still refresh since lease was created
+      router.refresh();
+      return;
+    }
+
+    setOpen(false);
+    resetForm();
+    router.refresh();
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) resetForm();
+      }}
+    >
+      <DialogTrigger render={<Button />}>
+        <Plus className="size-4" />
+        Create Lease
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create Lease</DialogTitle>
+          <DialogDescription>
+            Create a new lease and invite tenants.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {/* Section 1: Unit & Rent Terms */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">Unit & Rent Terms</h3>
+
+            <div className="space-y-2">
+              <Label>Unit</Label>
+              <Select
+                value={unitId}
+                onValueChange={(val) => setUnitId(val)}
+                required
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a unit" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableUnits.map((unit) => (
+                    <SelectItem key={unit.id} value={unit.id}>
+                      {unit.unit_number ?? 'Unnamed'}{' '}
+                      {unit.rent_amount != null &&
+                        `(${formatCurrency(unit.rent_amount)}/mo)`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="rent_amount">Monthly Rent</Label>
+              <Input
+                id="rent_amount"
+                name="rent_amount"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="0.00"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="security_deposit">Security Deposit</Label>
+              <Input
+                id="security_deposit"
+                name="security_deposit"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="0.00"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="start_date">Start Date</Label>
+                <Input
+                  id="start_date"
+                  name="start_date"
+                  type="date"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="end_date">
+                  End Date{' '}
+                  <span className="text-muted-foreground font-normal">
+                    (optional)
+                  </span>
+                </Label>
+                <Input id="end_date" name="end_date" type="date" />
+              </div>
+            </div>
+          </div>
+
+          {/* Section 2: Late Fee Settings */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">Late Fee Settings</h3>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="rent_due_day">Rent Due Day</Label>
+                <Input
+                  id="rent_due_day"
+                  name="rent_due_day"
+                  type="number"
+                  min="1"
+                  max="28"
+                  defaultValue="1"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="grace_period_days">Grace Period (days)</Label>
+                <Input
+                  id="grace_period_days"
+                  name="grace_period_days"
+                  type="number"
+                  min="0"
+                  max="30"
+                  defaultValue="5"
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="late_fee_amount">Late Fee Amount</Label>
+                <Input
+                  id="late_fee_amount"
+                  name="late_fee_amount"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  placeholder="0.00"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Late Fee Type</Label>
+                <Select
+                  value={lateFeeType}
+                  onValueChange={(val) => setLateFeeType(val as string)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="flat">Flat ($)</SelectItem>
+                    <SelectItem value="percentage">Percentage (%)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+
+          {/* Section 3: Tenants */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">Tenants</h3>
+
+            {tenantEmails.map((email, index) => (
+              <div key={index} className="flex items-end gap-2">
+                <div className="flex-1 space-y-2">
+                  <Label htmlFor={`tenant-email-${index}`}>
+                    {index === 0 ? 'Primary tenant' : `Tenant ${index + 1}`}
+                  </Label>
+                  <Input
+                    id={`tenant-email-${index}`}
+                    type="email"
+                    placeholder="tenant@example.com"
+                    value={email}
+                    onChange={(e) =>
+                      updateTenantEmail(index, e.currentTarget.value)
+                    }
+                  />
+                </div>
+                {tenantEmails.length > 1 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => removeTenantEmail(index)}
+                  >
+                    <X className="size-4" />
+                    <span className="sr-only">Remove</span>
+                  </Button>
+                )}
+              </div>
+            ))}
+
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={addTenantEmail}
+            >
+              <Plus className="size-4" />
+              Add Another Tenant
+            </Button>
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Creating...' : 'Create Lease'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(dashboard)/properties/[id]/delete-property-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/delete-property-dialog.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+export function DeletePropertyDialog({
+  propertyId,
+  propertyName,
+  open,
+  onOpenChange,
+}: {
+  propertyId: string;
+  propertyName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleDelete() {
+    setError(null);
+    setLoading(true);
+
+    const { error: deleteError } = await supabase
+      .from('properties')
+      .delete()
+      .eq('id', propertyId);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(false);
+    onOpenChange(false);
+    router.push('/properties');
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Delete Property</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete <strong>{propertyName}</strong>? This
+            will also delete all units associated with this property. This action
+            cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={loading}
+          >
+            {loading ? 'Deleting...' : 'Delete Property'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(dashboard)/properties/[id]/edit-property-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/edit-property-dialog.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { Database } from '@propnest/db';
+
+type Property = Database['public']['Tables']['properties']['Row'];
+
+export function EditPropertyDialog({
+  property,
+  open,
+  onOpenChange,
+}: {
+  property: Property;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const formData = new FormData(e.currentTarget);
+
+    const yearBuiltRaw = formData.get('year_built') as string;
+    const yearBuilt = yearBuiltRaw ? parseInt(yearBuiltRaw, 10) : null;
+
+    const { error: updateError } = await supabase
+      .from('properties')
+      .update({
+        name: formData.get('name') as string,
+        address_line1: formData.get('address_line1') as string,
+        address_line2: (formData.get('address_line2') as string) || null,
+        city: formData.get('city') as string,
+        state: formData.get('state') as string,
+        zip: formData.get('zip') as string,
+        property_type: (formData.get('property_type') as string) || null,
+        year_built: yearBuilt,
+        notes: (formData.get('notes') as string) || null,
+      })
+      .eq('id', property.id);
+
+    if (updateError) {
+      setError(updateError.message);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(false);
+    onOpenChange(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit Property</DialogTitle>
+          <DialogDescription>
+            Update the details for this property.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-name">Property Name</Label>
+            <Input
+              id="edit-name"
+              name="name"
+              defaultValue={property.name}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-address_line1">Address Line 1</Label>
+            <Input
+              id="edit-address_line1"
+              name="address_line1"
+              defaultValue={property.address_line1}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-address_line2">Address Line 2</Label>
+            <Input
+              id="edit-address_line2"
+              name="address_line2"
+              defaultValue={property.address_line2 ?? ''}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="edit-city">City</Label>
+              <Input
+                id="edit-city"
+                name="city"
+                defaultValue={property.city}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-state">State</Label>
+              <Input
+                id="edit-state"
+                name="state"
+                defaultValue={property.state}
+                maxLength={2}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-zip">ZIP Code</Label>
+              <Input
+                id="edit-zip"
+                name="zip"
+                defaultValue={property.zip}
+                required
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-property_type">Property Type</Label>
+              <Input
+                id="edit-property_type"
+                name="property_type"
+                defaultValue={property.property_type ?? ''}
+                placeholder="e.g. Residential, Commercial"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-year_built">Year Built</Label>
+              <Input
+                id="edit-year_built"
+                name="year_built"
+                type="number"
+                defaultValue={property.year_built ?? ''}
+                placeholder="e.g. 1995"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-notes">Notes</Label>
+            <Textarea
+              id="edit-notes"
+              name="notes"
+              defaultValue={property.notes ?? ''}
+              placeholder="Additional notes about this property"
+              rows={3}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(dashboard)/properties/[id]/edit-unit-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/edit-unit-dialog.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface Unit {
+  id: string;
+  unit_number: string | null;
+  bedrooms: number | null;
+  bathrooms: number | null;
+  square_feet: number | null;
+  rent_amount: number | null;
+  notes: string | null;
+}
+
+export function EditUnitDialog({
+  unit,
+  open,
+  onOpenChange,
+}: {
+  unit: Unit;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const formData = new FormData(e.currentTarget);
+
+    const { error: updateError } = await supabase
+      .from('units')
+      .update({
+        unit_number: (formData.get('unit_number') as string) || null,
+        bedrooms: formData.get('bedrooms')
+          ? Number(formData.get('bedrooms'))
+          : null,
+        bathrooms: formData.get('bathrooms')
+          ? Number(formData.get('bathrooms'))
+          : null,
+        square_feet: formData.get('square_feet')
+          ? Number(formData.get('square_feet'))
+          : null,
+        rent_amount: formData.get('rent_amount')
+          ? Number(formData.get('rent_amount'))
+          : null,
+        notes: (formData.get('notes') as string) || null,
+      })
+      .eq('id', unit.id);
+
+    if (updateError) {
+      setError(updateError.message);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(false);
+    onOpenChange(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit Unit</DialogTitle>
+          <DialogDescription>
+            Update the details for this unit.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="edit_unit_number">Unit Number</Label>
+            <Input
+              id="edit_unit_number"
+              name="unit_number"
+              defaultValue={unit.unit_number ?? ''}
+              placeholder="e.g. 101, A1"
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit_bedrooms">Bedrooms</Label>
+              <Input
+                id="edit_bedrooms"
+                name="bedrooms"
+                type="number"
+                step="0.5"
+                min="0"
+                defaultValue={unit.bedrooms ?? ''}
+                placeholder="e.g. 2"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit_bathrooms">Bathrooms</Label>
+              <Input
+                id="edit_bathrooms"
+                name="bathrooms"
+                type="number"
+                step="0.5"
+                min="0"
+                defaultValue={unit.bathrooms ?? ''}
+                placeholder="e.g. 1.5"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit_square_feet">Square Feet</Label>
+              <Input
+                id="edit_square_feet"
+                name="square_feet"
+                type="number"
+                min="0"
+                defaultValue={unit.square_feet ?? ''}
+                placeholder="e.g. 850"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit_rent_amount">Rent Amount</Label>
+              <Input
+                id="edit_rent_amount"
+                name="rent_amount"
+                type="number"
+                step="0.01"
+                min="0"
+                defaultValue={unit.rent_amount ?? ''}
+                placeholder="e.g. 1500.00"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit_notes">Notes</Label>
+            <Textarea
+              id="edit_notes"
+              name="notes"
+              defaultValue={unit.notes ?? ''}
+              placeholder="Additional notes about this unit"
+              rows={3}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(dashboard)/properties/[id]/leases-tab.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/leases-tab.tsx
@@ -1,5 +1,308 @@
 'use client';
 
-export function LeasesTab({ propertyId, units }: { propertyId: string; units: any[] }) {
-  return <p className="text-muted-foreground">Leases tab — coming next.</p>;
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { MoreHorizontal, Ban, Trash2 } from 'lucide-react';
+import { CreateLeaseDialog } from './create-lease-dialog';
+
+interface Unit {
+  id: string;
+  unit_number: string | null;
+  rent_amount: number | null;
+}
+
+interface LeaseTenant {
+  id: string;
+  accepted_at: string | null;
+}
+
+interface Lease {
+  id: string;
+  unit_id: string;
+  status: 'draft' | 'active' | 'expired' | 'terminated';
+  start_date: string;
+  end_date: string | null;
+  rent_amount: number;
+  lease_tenants: LeaseTenant[];
+}
+
+interface FlattenedLease extends Lease {
+  unit_number: string | null;
+}
+
+const statusBadgeVariant: Record<
+  string,
+  'default' | 'secondary' | 'outline' | 'destructive'
+> = {
+  active: 'default',
+  draft: 'secondary',
+  expired: 'outline',
+  terminated: 'destructive',
+};
+
+export function LeasesTab({
+  propertyId,
+  units,
+}: {
+  propertyId: string;
+  units: Unit[];
+}) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [error, setError] = useState<string | null>(null);
+  const [leases, setLeases] = useState<FlattenedLease[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function fetchLeases() {
+      const unitIds = units.map((u) => u.id);
+      if (unitIds.length === 0) {
+        setLeases([]);
+        setLoaded(true);
+        return;
+      }
+
+      const { data, error: fetchError } = await supabase
+        .from('leases')
+        .select('id, unit_id, status, start_date, end_date, rent_amount')
+        .in('unit_id', unitIds)
+        .order('start_date', { ascending: false });
+
+      if (fetchError) {
+        setError(fetchError.message);
+        setLoaded(true);
+        return;
+      }
+
+      const leaseIds = (data ?? []).map((l) => l.id);
+
+      // Fetch lease_tenants separately since relationship isn't in generated types
+      let tenantsByLease: Record<string, LeaseTenant[]> = {};
+      if (leaseIds.length > 0) {
+        const { data: tenants } = await supabase
+          .from('lease_tenants')
+          .select('id, lease_id, accepted_at')
+          .in('lease_id', leaseIds);
+
+        for (const t of tenants ?? []) {
+          if (!tenantsByLease[t.lease_id]) {
+            tenantsByLease[t.lease_id] = [];
+          }
+          tenantsByLease[t.lease_id].push({
+            id: t.id,
+            accepted_at: t.accepted_at,
+          });
+        }
+      }
+
+      const unitMap = new Map(units.map((u) => [u.id, u]));
+      const flattened: FlattenedLease[] = (data ?? []).map((lease) => ({
+        ...lease,
+        status: lease.status as Lease['status'],
+        lease_tenants: tenantsByLease[lease.id] ?? [],
+        unit_number: unitMap.get(lease.unit_id)?.unit_number ?? null,
+      }));
+
+      setLeases(flattened);
+      setLoaded(true);
+    }
+
+    fetchLeases();
+  }, [units, supabase]);
+
+  const activeLeaseUnitIds = new Set(
+    leases.filter((l) => l.status === 'active').map((l) => l.unit_id)
+  );
+
+  async function handleTerminate(leaseId: string) {
+    setError(null);
+    const { error: updateError } = await supabase
+      .from('leases')
+      .update({ status: 'terminated' as const })
+      .eq('id', leaseId);
+
+    if (updateError) {
+      setError(updateError.message);
+      return;
+    }
+
+    router.refresh();
+    // Also update local state
+    setLeases((prev) =>
+      prev.map((l) =>
+        l.id === leaseId ? { ...l, status: 'terminated' as const } : l
+      )
+    );
+  }
+
+  async function handleDelete(leaseId: string) {
+    setError(null);
+    const { error: deleteError } = await supabase
+      .from('leases')
+      .delete()
+      .eq('id', leaseId);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      return;
+    }
+
+    router.refresh();
+    setLeases((prev) => prev.filter((l) => l.id !== leaseId));
+  }
+
+  function formatCurrency(amount: number) {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(amount);
+  }
+
+  function formatDate(dateStr: string) {
+    return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  if (!loaded) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Leases</h2>
+        </div>
+        <p className="text-muted-foreground">Loading leases...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Leases</h2>
+        <CreateLeaseDialog
+          propertyId={propertyId}
+          units={units}
+          activeLeaseUnitIds={activeLeaseUnitIds}
+        />
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {leases.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-muted-foreground">
+            No leases yet. Create your first lease to get started.
+          </p>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Unit</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Rent</TableHead>
+              <TableHead>Start Date</TableHead>
+              <TableHead>End Date</TableHead>
+              <TableHead>Tenants</TableHead>
+              <TableHead className="w-12">
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {leases.map((lease) => {
+              const tenantCount = lease.lease_tenants.length;
+              const pendingCount = lease.lease_tenants.filter(
+                (t) => !t.accepted_at
+              ).length;
+
+              return (
+                <TableRow key={lease.id}>
+                  <TableCell className="font-medium">
+                    {lease.unit_number ?? '—'}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={statusBadgeVariant[lease.status] ?? 'outline'}>
+                      {lease.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>{formatCurrency(lease.rent_amount)}/mo</TableCell>
+                  <TableCell>{formatDate(lease.start_date)}</TableCell>
+                  <TableCell>
+                    {lease.end_date
+                      ? formatDate(lease.end_date)
+                      : 'Month-to-month'}
+                  </TableCell>
+                  <TableCell>
+                    {tenantCount}
+                    {pendingCount > 0 && (
+                      <span className="ml-1 text-xs text-muted-foreground">
+                        ({pendingCount} pending)
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        render={
+                          <Button variant="ghost" size="icon-sm" />
+                        }
+                      >
+                        <MoreHorizontal className="size-4" />
+                        <span className="sr-only">Actions</span>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {lease.status === 'active' && (
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onClick={() => handleTerminate(lease.id)}
+                          >
+                            <Ban />
+                            Terminate
+                          </DropdownMenuItem>
+                        )}
+                        {lease.status === 'draft' && (
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onClick={() => handleDelete(lease.id)}
+                          >
+                            <Trash2 />
+                            Delete
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
 }

--- a/apps/web/src/app/(dashboard)/properties/[id]/leases-tab.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/leases-tab.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export function LeasesTab({ propertyId, units }: { propertyId: string; units: any[] }) {
+  return <p className="text-muted-foreground">Leases tab — coming next.</p>;
+}

--- a/apps/web/src/app/(dashboard)/properties/[id]/overview-tab.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/overview-tab.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { EditPropertyDialog } from './edit-property-dialog';
+import { DeletePropertyDialog } from './delete-property-dialog';
+import { MapPinIcon, PencilIcon, Trash2Icon } from 'lucide-react';
+import type { Database } from '@propnest/db';
+
+type Property = Database['public']['Tables']['properties']['Row'];
+
+export function OverviewTab({ property }: { property: Property }) {
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  return (
+    <div className="space-y-6 pt-4">
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+          <PencilIcon className="size-4" />
+          Edit
+        </Button>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={() => setDeleteOpen(true)}
+        >
+          <Trash2Icon className="size-4" />
+          Delete
+        </Button>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Address
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-start gap-2">
+              <MapPinIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+              <div className="text-sm">
+                <p>{property.address_line1}</p>
+                {property.address_line2 && <p>{property.address_line2}</p>}
+                <p>
+                  {property.city}, {property.state} {property.zip}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Details
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="space-y-2 text-sm">
+              {property.property_type && (
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Type</dt>
+                  <dd>{property.property_type}</dd>
+                </div>
+              )}
+              {property.year_built && (
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Year Built</dt>
+                  <dd>{property.year_built}</dd>
+                </div>
+              )}
+            </dl>
+          </CardContent>
+        </Card>
+
+        {property.notes && (
+          <Card className="sm:col-span-2">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                Notes
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm whitespace-pre-wrap">{property.notes}</p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      <EditPropertyDialog
+        property={property}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+      />
+      <DeletePropertyDialog
+        propertyId={property.id}
+        propertyName={property.name}
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/properties/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/page.tsx
@@ -1,0 +1,77 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { createServerClient } from '@/lib/supabase/server';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { OverviewTab } from './overview-tab';
+import { UnitsTab } from './units-tab';
+import { LeasesTab } from './leases-tab';
+import { ArrowLeftIcon } from 'lucide-react';
+
+export default async function PropertyDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createServerClient();
+
+  // Fetch property
+  const { data: property } = await supabase
+    .from('properties')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (!property) {
+    notFound();
+  }
+
+  // Fetch units for this property
+  const { data: units } = await supabase
+    .from('units')
+    .select('id, unit_number, bedrooms, bathrooms, square_feet, rent_amount, is_available, notes')
+    .eq('property_id', id)
+    .order('unit_number');
+
+  const unitList = units ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Link href="/properties">
+          <Button variant="ghost" size="icon-sm">
+            <ArrowLeftIcon className="size-4" />
+          </Button>
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{property.name}</h1>
+          <p className="text-sm text-muted-foreground">
+            {property.address_line1}, {property.city}, {property.state}{' '}
+            {property.zip}
+          </p>
+        </div>
+      </div>
+
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="units">Units</TabsTrigger>
+          <TabsTrigger value="leases">Leases</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview">
+          <OverviewTab property={property} />
+        </TabsContent>
+
+        <TabsContent value="units">
+          <UnitsTab propertyId={property.id} units={unitList} />
+        </TabsContent>
+
+        <TabsContent value="leases">
+          <LeasesTab propertyId={property.id} units={unitList} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/properties/[id]/units-tab.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/units-tab.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export function UnitsTab({ propertyId, units }: { propertyId: string; units: any[] }) {
+  return <p className="text-muted-foreground">Units tab — coming next.</p>;
+}

--- a/apps/web/src/app/(dashboard)/properties/[id]/units-tab.tsx
+++ b/apps/web/src/app/(dashboard)/properties/[id]/units-tab.tsx
@@ -1,5 +1,179 @@
 'use client';
 
-export function UnitsTab({ propertyId, units }: { propertyId: string; units: any[] }) {
-  return <p className="text-muted-foreground">Units tab — coming next.</p>;
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { MoreHorizontalIcon, PencilIcon, Trash2Icon } from 'lucide-react';
+import { AddUnitDialog } from './add-unit-dialog';
+import { EditUnitDialog } from './edit-unit-dialog';
+
+interface Unit {
+  id: string;
+  unit_number: string | null;
+  bedrooms: number | null;
+  bathrooms: number | null;
+  square_feet: number | null;
+  rent_amount: number | null;
+  is_available: boolean;
+  notes: string | null;
+}
+
+export function UnitsTab({
+  propertyId,
+  units,
+}: {
+  propertyId: string;
+  units: Unit[];
+}) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [error, setError] = useState<string | null>(null);
+  const [editingUnit, setEditingUnit] = useState<Unit | null>(null);
+
+  async function handleDelete(unitId: string) {
+    setError(null);
+
+    const { error: deleteError } = await supabase
+      .from('units')
+      .delete()
+      .eq('id', unitId);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      return;
+    }
+
+    router.refresh();
+  }
+
+  function formatCurrency(amount: number | null) {
+    if (amount == null) return '—';
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(amount);
+  }
+
+  function formatBedBath(bedrooms: number | null, bathrooms: number | null) {
+    const bed = bedrooms != null ? `${bedrooms} bd` : '—';
+    const bath = bathrooms != null ? `${bathrooms} ba` : '—';
+    return `${bed} / ${bath}`;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Units</h2>
+        <AddUnitDialog propertyId={propertyId} />
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {units.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-muted-foreground">
+            No units yet. Add your first unit to get started.
+          </p>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Unit Number</TableHead>
+              <TableHead>Bed / Bath</TableHead>
+              <TableHead>Sq Ft</TableHead>
+              <TableHead>Rent</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="w-12">
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {units.map((unit) => (
+              <TableRow key={unit.id}>
+                <TableCell className="font-medium">
+                  {unit.unit_number ?? '—'}
+                </TableCell>
+                <TableCell>
+                  {formatBedBath(unit.bedrooms, unit.bathrooms)}
+                </TableCell>
+                <TableCell>
+                  {unit.square_feet != null
+                    ? unit.square_feet.toLocaleString()
+                    : '—'}
+                </TableCell>
+                <TableCell>{formatCurrency(unit.rent_amount)}</TableCell>
+                <TableCell>
+                  {unit.is_available ? (
+                    <Badge variant="secondary">Available</Badge>
+                  ) : (
+                    <Badge variant="default">Occupied</Badge>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={
+                        <Button variant="ghost" size="icon-sm" />
+                      }
+                    >
+                      <MoreHorizontalIcon className="size-4" />
+                      <span className="sr-only">Actions</span>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => setEditingUnit(unit)}
+                      >
+                        <PencilIcon />
+                        Edit
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onClick={() => handleDelete(unit.id)}
+                      >
+                        <Trash2Icon />
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {editingUnit && (
+        <EditUnitDialog
+          unit={editingUnit}
+          open={!!editingUnit}
+          onOpenChange={(open) => {
+            if (!open) setEditingUnit(null);
+          }}
+        />
+      )}
+    </div>
+  );
 }

--- a/apps/web/src/app/(dashboard)/properties/add-property-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/properties/add-property-dialog.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { PlusIcon } from 'lucide-react';
+
+export function AddPropertyDialog({ organizationId }: { organizationId: string }) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const formData = new FormData(e.currentTarget);
+
+    const { error: insertError } = await supabase.from('properties').insert({
+      organization_id: organizationId,
+      name: formData.get('name') as string,
+      address_line1: formData.get('address_line1') as string,
+      address_line2: (formData.get('address_line2') as string) || null,
+      city: formData.get('city') as string,
+      state: formData.get('state') as string,
+      zip: formData.get('zip') as string,
+      property_type: (formData.get('property_type') as string) || null,
+      notes: (formData.get('notes') as string) || null,
+    });
+
+    if (insertError) {
+      setError(insertError.message);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(false);
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button />}>
+        <PlusIcon className="size-4" />
+        Add Property
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add Property</DialogTitle>
+          <DialogDescription>
+            Add a new property to your portfolio.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="name">Property Name</Label>
+            <Input id="name" name="name" placeholder="e.g. Sunset Apartments" required />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="address_line1">Address Line 1</Label>
+            <Input id="address_line1" name="address_line1" placeholder="123 Main St" required />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="address_line2">Address Line 2</Label>
+            <Input id="address_line2" name="address_line2" placeholder="Suite 100" />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="city">City</Label>
+              <Input id="city" name="city" placeholder="City" required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="state">State</Label>
+              <Input id="state" name="state" placeholder="CA" maxLength={2} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="zip">ZIP Code</Label>
+              <Input id="zip" name="zip" placeholder="90210" required />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="property_type">Property Type</Label>
+            <Input id="property_type" name="property_type" placeholder="e.g. Residential, Commercial" />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes</Label>
+            <Textarea id="notes" name="notes" placeholder="Additional notes about this property" rows={3} />
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Adding...' : 'Add Property'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(dashboard)/properties/page.tsx
+++ b/apps/web/src/app/(dashboard)/properties/page.tsx
@@ -1,0 +1,143 @@
+import Link from 'next/link';
+import { createServerClient } from '@/lib/supabase/server';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { AddPropertyDialog } from './add-property-dialog';
+import { Building2Icon, HomeIcon } from 'lucide-react';
+
+export default async function PropertiesPage() {
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Fetch org membership
+  const { data: membership } = await supabase
+    .from('organization_members')
+    .select('organization_id')
+    .eq('user_id', user!.id)
+    .not('accepted_at', 'is', null)
+    .limit(1)
+    .single();
+
+  if (!membership) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-20">
+        <Building2Icon className="size-12 text-muted-foreground" />
+        <h2 className="text-xl font-semibold">Not a member of any organization</h2>
+        <p className="text-muted-foreground">
+          You need to be part of an organization to view properties.
+        </p>
+      </div>
+    );
+  }
+
+  const organizationId = membership.organization_id;
+
+  // Fetch properties
+  const { data: properties } = await supabase
+    .from('properties')
+    .select('id, name, address_line1, city, state, zip, property_type')
+    .eq('organization_id', organizationId)
+    .order('name');
+
+  const propertyList = properties ?? [];
+
+  // Fetch unit counts per property
+  const propertyIds = propertyList.map((p) => p.id);
+  let unitCountMap: Record<string, number> = {};
+  let leaseCountMap: Record<string, number> = {};
+
+  if (propertyIds.length > 0) {
+    const { data: units } = await supabase
+      .from('units')
+      .select('id, property_id')
+      .in('property_id', propertyIds);
+
+    if (units) {
+      for (const unit of units) {
+        unitCountMap[unit.property_id] = (unitCountMap[unit.property_id] ?? 0) + 1;
+      }
+
+      const unitIds = units.map((u) => u.id);
+      if (unitIds.length > 0) {
+        const { data: leases } = await supabase
+          .from('leases')
+          .select('id, unit_id')
+          .in('unit_id', unitIds);
+
+        if (leases) {
+          // Map unit_id -> property_id
+          const unitPropertyMap: Record<string, string> = {};
+          for (const unit of units) {
+            unitPropertyMap[unit.id] = unit.property_id;
+          }
+          for (const lease of leases) {
+            const propId = unitPropertyMap[lease.unit_id];
+            if (propId) {
+              leaseCountMap[propId] = (leaseCountMap[propId] ?? 0) + 1;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Properties</h1>
+          <p className="text-muted-foreground">
+            Manage properties in your portfolio.
+          </p>
+        </div>
+        <AddPropertyDialog organizationId={organizationId} />
+      </div>
+
+      {propertyList.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed py-20">
+          <HomeIcon className="size-12 text-muted-foreground" />
+          <h2 className="text-lg font-semibold">No properties yet</h2>
+          <p className="text-muted-foreground">
+            Add your first property to get started.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {propertyList.map((property) => {
+            const unitCount = unitCountMap[property.id] ?? 0;
+            const leaseCount = leaseCountMap[property.id] ?? 0;
+
+            return (
+              <Link key={property.id} href={`/properties/${property.id}`}>
+                <Card className="transition-colors hover:border-primary/50">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="flex items-start justify-between gap-2 text-base">
+                      <span className="line-clamp-1">{property.name}</span>
+                      {property.property_type && (
+                        <Badge variant="secondary" className="shrink-0 text-xs">
+                          {property.property_type}
+                        </Badge>
+                      )}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <p className="text-sm text-muted-foreground">
+                      {property.address_line1}, {property.city}, {property.state} {property.zip}
+                    </p>
+                    <div className="flex gap-2">
+                      <Badge variant="outline">{unitCount} {unitCount === 1 ? 'unit' : 'units'}</Badge>
+                      <Badge variant="outline">{leaseCount} {leaseCount === 1 ? 'lease' : 'leases'}</Badge>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -3,10 +3,11 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import { LayoutDashboard } from 'lucide-react';
+import { LayoutDashboard, Building2 } from 'lucide-react';
 
 const navItems = [
   { href: '/', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/properties', label: 'Properties', icon: Building2 },
 ];
 
 export function Sidebar() {
@@ -22,7 +23,9 @@ export function Sidebar() {
       <nav className="space-y-1 p-2">
         {navItems.map((item) => {
           const Icon = item.icon;
-          const isActive = pathname === item.href;
+          const isActive = item.href === '/'
+            ? pathname === '/'
+            : pathname === item.href || pathname.startsWith(item.href + '/');
           return (
             <Link
               key={item.href}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/docs/plans/2026-03-27-phase6-property-lease-management-design.md
+++ b/docs/plans/2026-03-27-phase6-property-lease-management-design.md
@@ -1,0 +1,97 @@
+# Phase 6: Property & Lease Management UI — Design
+
+> **Date:** 2026-03-27
+> **Status:** Approved
+> **Scope:** Landlord-side only (owner/manager). Tenants keep current dashboard.
+
+---
+
+## Decisions
+
+| Question | Answer |
+|----------|--------|
+| Who is this for? | Owners and managers only |
+| Navigation model | Property-centric with tabs (Overview, Units, Leases) |
+| Create/edit pattern | Modal dialogs for everything |
+| Lease + tenant invite | Combined — tenant emails entered during lease creation |
+
+---
+
+## Routes & Navigation
+
+**Sidebar addition** (visible to owner/manager only):
+- Properties (`/properties`)
+
+**Route structure:**
+```
+(dashboard)/
+  properties/
+    page.tsx                    — Properties list
+    [id]/
+      page.tsx                  — Property detail with tabs
+```
+
+Property detail page has 3 tabs: Overview, Units, Leases.
+
+---
+
+## UI Flow
+
+### Properties List (`/properties`)
+Cards showing property name, address, unit count, active lease count. "Add Property" button opens modal form (name, address fields, notes).
+
+### Property Detail (`/properties/[id]`)
+
+**Overview tab** — Read-only display of property info (name, full address, property type, year built, notes). "Edit" button opens same modal form pre-filled. "Delete" button with confirmation dialog.
+
+**Units tab** — Table: unit number, bedrooms, bathrooms, sqft, rent amount, availability status. "Add Unit" opens modal. Row actions dropdown (edit, delete). Delete blocked if unit has active lease (DB constraint).
+
+**Leases tab** — Table: unit, status badge, tenant email(s), rent amount, start/end dates. "Create Lease" opens multi-section modal:
+1. Select unit (dropdown of available units in this property), rent amount, start date, end date
+2. Rent due day (1-28), grace period days, late fee type (flat/percentage), late fee amount
+3. Tenant email(s) — sends invite via existing `invite-tenant` Edge Function
+
+Lease saves as `draft` status. Tenant invites sent immediately.
+
+Row actions: Edit (draft only), Terminate (active only), Delete (draft only).
+
+---
+
+## Data Fetching
+
+All reads via server components using `createServerClient()`. RLS handles authorization — no new Edge Functions for CRUD.
+
+Mutations via client components using `createBrowserClient()`:
+- Property/unit CRUD → direct `.insert()` / `.update()` / `.delete()` on Supabase
+- Lease create → direct insert + call `invite-tenant` Edge Function per tenant email
+- Lease terminate → `.update({ status: 'terminated' })`
+
+---
+
+## New shadcn/ui Components
+
+- `table` — unit and lease lists
+- `dialog` — all create/edit modals
+- `select` — unit dropdown, late fee type, property type
+- `tabs` — property detail page
+- `textarea` — notes fields
+- `dropdown-menu` — row actions (edit, delete, terminate)
+
+---
+
+## Validation
+
+Reuse Zod schemas from `packages/validators`:
+- `CreatePropertySchema` / `UpdatePropertySchema`
+- `CreateUnitSchema` / `UpdateUnitSchema`
+- `CreateLeaseSchema` / `UpdateLeaseSchema`
+
+Client-side validation before Supabase calls. Server-side enforced by DB constraints + RLS.
+
+---
+
+## Deletion Rules
+
+- **Property**: Confirmation dialog. Cascades to units via DB constraint.
+- **Unit**: Blocked if unit has active lease (`ON DELETE RESTRICT` on leases FK).
+- **Lease**: Only `draft` leases deletable. Active leases can be terminated (status change). Expired leases are read-only.

--- a/docs/plans/2026-03-27-phase6-property-lease-management-plan.md
+++ b/docs/plans/2026-03-27-phase6-property-lease-management-plan.md
@@ -1,0 +1,1775 @@
+# Phase 6: Property & Lease Management UI — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build landlord-side UI for managing properties, units, and leases with modal-based CRUD and tenant invite integration.
+
+**Architecture:** Server components for data fetching (RLS handles auth), client components for mutations via `createBrowserClient()`. Property-centric navigation with tabbed detail view. No new Edge Functions — direct Supabase queries for CRUD, existing `invite-tenant` function for tenant invites.
+
+**Tech Stack:** Next.js 16, React 19, Supabase SSR, shadcn/ui (base-nova style), Zod validators from `@propnest/validators`, Lucide icons, Tailwind CSS.
+
+**IMPORTANT — Next.js 16 breaking changes:** Read `node_modules/next/dist/docs/` before modifying middleware/proxy. The file is `proxy.ts` with `export function proxy()`, NOT `middleware.ts`.
+
+---
+
+### Task 1: Install shadcn/ui Components
+
+We need table, dialog, select, tabs, textarea, and dropdown-menu components that don't exist yet.
+
+**Files:**
+- Create: `apps/web/src/components/ui/table.tsx`
+- Create: `apps/web/src/components/ui/dialog.tsx`
+- Create: `apps/web/src/components/ui/select.tsx`
+- Create: `apps/web/src/components/ui/tabs.tsx`
+- Create: `apps/web/src/components/ui/textarea.tsx`
+- Create: `apps/web/src/components/ui/dropdown-menu.tsx`
+
+**Step 1: Install all 6 components**
+
+```bash
+cd apps/web
+npx shadcn@latest add table dialog select tabs textarea dropdown-menu
+```
+
+When prompted, accept defaults. This reads `components.json` (style: base-nova) and generates the files.
+
+**Step 2: Verify all files were created**
+
+```bash
+ls apps/web/src/components/ui/{table,dialog,select,tabs,textarea,dropdown-menu}.tsx
+```
+
+Expected: All 6 files listed.
+
+**Step 3: Typecheck**
+
+```bash
+pnpm turbo typecheck
+```
+
+Expected: All packages pass.
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/components/ui/ apps/web/package.json pnpm-lock.yaml
+git commit -m "chore: add shadcn/ui table, dialog, select, tabs, textarea, dropdown-menu"
+```
+
+---
+
+### Task 2: Add Properties Link to Sidebar
+
+**Files:**
+- Modify: `apps/web/src/components/sidebar.tsx`
+
+**Step 1: Add the Building2 icon import and Properties nav item**
+
+In `apps/web/src/components/sidebar.tsx`:
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+import { LayoutDashboard, Building2 } from 'lucide-react';
+
+const navItems = [
+  { href: '/', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/properties', label: 'Properties', icon: Building2 },
+];
+
+export function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="hidden w-64 border-r bg-muted/30 md:block">
+      <div className="flex h-14 items-center border-b px-4">
+        <Link href="/" className="text-lg font-semibold">
+          PropNest
+        </Link>
+      </div>
+      <nav className="space-y-1 p-2">
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          const isActive = pathname === item.href || pathname.startsWith(item.href + '/');
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                isActive
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}
+```
+
+Note: The `isActive` check now also matches sub-routes (`/properties/[id]`). The Dashboard item still only matches exact `/` because `'/' + '/'` won't match sub-routes — but we need to special-case it. Update the isActive logic:
+
+```tsx
+const isActive = item.href === '/'
+  ? pathname === '/'
+  : pathname === item.href || pathname.startsWith(item.href + '/');
+```
+
+**Step 2: Verify build**
+
+```bash
+cd apps/web && pnpm build
+```
+
+Expected: Build succeeds.
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/components/sidebar.tsx
+git commit -m "feat: add Properties link to sidebar navigation"
+```
+
+---
+
+### Task 3: Properties List Page
+
+**Files:**
+- Create: `apps/web/src/app/(dashboard)/properties/page.tsx`
+- Create: `apps/web/src/app/(dashboard)/properties/property-card.tsx`
+- Create: `apps/web/src/app/(dashboard)/properties/add-property-dialog.tsx`
+
+**Context:**
+- `createServerClient` is imported from `@/lib/supabase/server` (async function, returns typed Supabase client)
+- `getSupabaseBrowserClient` is imported from `@/lib/supabase/client` (singleton browser client)
+- The dashboard layout already verifies auth and redirects to `/login` if not authenticated
+- The layout fetches `organization_members` with role — but does NOT pass org_id to children. The properties page must fetch the user's org_id itself.
+- RLS on `properties` table: org members (owner|manager) can SELECT properties in their org. So a simple `.select()` returns only the user's org's properties.
+- Zod validators: `CreatePropertySchema` from `@propnest/validators` requires `organization_id`, `name`, `address_line1`, `city`, `state`, `zip`. Optional: `address_line2`, `country`, `property_type`, `year_built`, `notes`.
+
+**Step 1: Create the properties list page (server component)**
+
+Create `apps/web/src/app/(dashboard)/properties/page.tsx`:
+
+```tsx
+import Link from 'next/link';
+import { createServerClient } from '@/lib/supabase/server';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Building2, MapPin } from 'lucide-react';
+import { AddPropertyDialog } from './add-property-dialog';
+
+export default async function PropertiesPage() {
+  const supabase = await createServerClient();
+
+  // Get user's org
+  const { data: { user } } = await supabase.auth.getUser();
+  const { data: membership } = await supabase
+    .from('organization_members')
+    .select('organization_id, role')
+    .eq('user_id', user!.id)
+    .not('accepted_at', 'is', null)
+    .limit(1)
+    .single();
+
+  if (!membership) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Properties</h1>
+        <p className="text-muted-foreground">You are not a member of any organization.</p>
+      </div>
+    );
+  }
+
+  // Fetch properties with unit and active lease counts
+  const { data: properties } = await supabase
+    .from('properties')
+    .select('id, name, address_line1, city, state, zip, property_type, units(id, leases(id))')
+    .eq('organization_id', membership.organization_id)
+    .order('name');
+
+  // Compute counts
+  const propertiesWithCounts = (properties ?? []).map((p: any) => ({
+    ...p,
+    unitCount: p.units?.length ?? 0,
+    activeLeaseCount: p.units?.reduce(
+      (sum: number, u: any) => sum + (u.leases?.length ?? 0),
+      0,
+    ) ?? 0,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Properties</h1>
+        <AddPropertyDialog organizationId={membership.organization_id} />
+      </div>
+
+      {propertiesWithCounts.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            No properties yet. Add your first property to get started.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {propertiesWithCounts.map((property: any) => (
+            <Link key={property.id} href={`/properties/${property.id}`}>
+              <Card className="transition-colors hover:border-primary/50">
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Building2 className="h-4 w-4 text-muted-foreground" />
+                    {property.name}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <p className="flex items-center gap-1 text-sm text-muted-foreground">
+                    <MapPin className="h-3 w-3" />
+                    {property.address_line1}, {property.city}, {property.state} {property.zip}
+                  </p>
+                  <div className="flex gap-2">
+                    <Badge variant="secondary">{property.unitCount} unit{property.unitCount !== 1 ? 's' : ''}</Badge>
+                    <Badge variant="secondary">{property.activeLeaseCount} active lease{property.activeLeaseCount !== 1 ? 's' : ''}</Badge>
+                  </div>
+                  {property.property_type && (
+                    <p className="text-xs text-muted-foreground capitalize">{property.property_type}</p>
+                  )}
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+Note: The nested select `units(id, leases(id))` works because RLS allows org members to read both. The leases sub-query returns all leases for the unit (not filtered by status). To only count active leases, we'd need to filter — but the Supabase `.select()` nested filter syntax is `leases!inner(id)` with `.eq()` which doesn't work for counts. For now, show total lease count. This can be refined later.
+
+**Step 2: Create the AddPropertyDialog client component**
+
+Create `apps/web/src/app/(dashboard)/properties/add-property-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Plus } from 'lucide-react';
+
+interface AddPropertyDialogProps {
+  organizationId: string;
+}
+
+export function AddPropertyDialog({ organizationId }: AddPropertyDialogProps) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const form = new FormData(e.currentTarget);
+
+    const { error: insertError } = await supabase.from('properties').insert({
+      organization_id: organizationId,
+      name: form.get('name') as string,
+      address_line1: form.get('address_line1') as string,
+      address_line2: (form.get('address_line2') as string) || null,
+      city: form.get('city') as string,
+      state: form.get('state') as string,
+      zip: form.get('zip') as string,
+      property_type: (form.get('property_type') as string) || null,
+      notes: (form.get('notes') as string) || null,
+    });
+
+    setLoading(false);
+
+    if (insertError) {
+      setError(insertError.message);
+      return;
+    }
+
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
+          Add Property
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add Property</DialogTitle>
+          <DialogDescription>Enter the property details.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="name">Property Name</Label>
+            <Input id="name" name="name" placeholder="e.g. Sunset Apartments" required />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="address_line1">Address</Label>
+            <Input id="address_line1" name="address_line1" placeholder="123 Main St" required />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="address_line2">Address Line 2</Label>
+            <Input id="address_line2" name="address_line2" placeholder="Suite 100" />
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="city">City</Label>
+              <Input id="city" name="city" required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="state">State</Label>
+              <Input id="state" name="state" maxLength={2} placeholder="CA" required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="zip">ZIP</Label>
+              <Input id="zip" name="zip" required />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="property_type">Property Type</Label>
+            <Input id="property_type" name="property_type" placeholder="e.g. apartment, single-family" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes</Label>
+            <Textarea id="notes" name="notes" rows={2} />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving...' : 'Add Property'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+**Step 3: Verify build**
+
+```bash
+cd apps/web && pnpm build
+```
+
+Expected: Build succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/app/\(dashboard\)/properties/
+git commit -m "feat: add properties list page with add property dialog"
+```
+
+---
+
+### Task 4: Property Detail Page with Tabs
+
+**Files:**
+- Create: `apps/web/src/app/(dashboard)/properties/[id]/page.tsx`
+- Create: `apps/web/src/app/(dashboard)/properties/[id]/overview-tab.tsx`
+- Create: `apps/web/src/app/(dashboard)/properties/[id]/edit-property-dialog.tsx`
+- Create: `apps/web/src/app/(dashboard)/properties/[id]/delete-property-dialog.tsx`
+
+**Context:**
+- Route param is `id` (property UUID). Access via `params.id` in Next.js 16 (note: `params` is a Promise in Next.js 16 — must `await params`).
+- Property detail fetches the property with all its units and leases via a nested select.
+- Tabs: Overview, Units, Leases. Units and Leases tabs are separate tasks.
+
+**Step 1: Create the property detail page (server component)**
+
+Create `apps/web/src/app/(dashboard)/properties/[id]/page.tsx`:
+
+```tsx
+import { notFound } from 'next/navigation';
+import { createServerClient } from '@/lib/supabase/server';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { OverviewTab } from './overview-tab';
+import { UnitsTab } from './units-tab';
+import { LeasesTab } from './leases-tab';
+
+export default async function PropertyDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = await createServerClient();
+
+  const { data: property } = await supabase
+    .from('properties')
+    .select(`
+      *,
+      units(
+        id, unit_number, bedrooms, bathrooms, square_feet, rent_amount, is_available, notes,
+        leases(id, status, start_date, end_date, rent_amount, rent_due_day, grace_period_days, late_fee_type, late_fee_amount, notes,
+          lease_tenants(id, user_id, is_primary, accepted_at)
+        )
+      )
+    `)
+    .eq('id', id)
+    .single();
+
+  if (!property) notFound();
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">{property.name}</h1>
+
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="units">Units ({property.units?.length ?? 0})</TabsTrigger>
+          <TabsTrigger value="leases">Leases</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview" className="mt-4">
+          <OverviewTab property={property} />
+        </TabsContent>
+        <TabsContent value="units" className="mt-4">
+          <UnitsTab propertyId={property.id} units={property.units ?? []} />
+        </TabsContent>
+        <TabsContent value="leases" className="mt-4">
+          <LeasesTab propertyId={property.id} units={property.units ?? []} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+```
+
+**Step 2: Create the OverviewTab (client component for edit/delete)**
+
+Create `apps/web/src/app/(dashboard)/properties/[id]/overview-tab.tsx`:
+
+```tsx
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { MapPin } from 'lucide-react';
+import { EditPropertyDialog } from './edit-property-dialog';
+import { DeletePropertyDialog } from './delete-property-dialog';
+
+interface OverviewTabProps {
+  property: {
+    id: string;
+    name: string;
+    address_line1: string;
+    address_line2?: string | null;
+    city: string;
+    state: string;
+    zip: string;
+    country: string;
+    property_type?: string | null;
+    year_built?: number | null;
+    notes?: string | null;
+    organization_id: string;
+  };
+}
+
+export function OverviewTab({ property }: OverviewTabProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Property Details</CardTitle>
+        <div className="flex gap-2">
+          <EditPropertyDialog property={property} />
+          <DeletePropertyDialog propertyId={property.id} propertyName={property.name} />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-start gap-2">
+          <MapPin className="mt-0.5 h-4 w-4 text-muted-foreground" />
+          <div>
+            <p>{property.address_line1}</p>
+            {property.address_line2 && <p>{property.address_line2}</p>}
+            <p>{property.city}, {property.state} {property.zip}</p>
+          </div>
+        </div>
+        {property.property_type && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Type</p>
+            <p className="capitalize">{property.property_type}</p>
+          </div>
+        )}
+        {property.year_built && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Year Built</p>
+            <p>{property.year_built}</p>
+          </div>
+        )}
+        {property.notes && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Notes</p>
+            <p className="whitespace-pre-wrap">{property.notes}</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+**Step 3: Create the EditPropertyDialog**
+
+Create `apps/web/src/app/(dashboard)/properties/[id]/edit-property-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle, DialogTrigger,
+} from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Pencil } from 'lucide-react';
+
+interface EditPropertyDialogProps {
+  property: {
+    id: string;
+    name: string;
+    address_line1: string;
+    address_line2?: string | null;
+    city: string;
+    state: string;
+    zip: string;
+    property_type?: string | null;
+    year_built?: number | null;
+    notes?: string | null;
+  };
+}
+
+export function EditPropertyDialog({ property }: EditPropertyDialogProps) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const form = new FormData(e.currentTarget);
+    const yearBuilt = form.get('year_built') as string;
+
+    const { error: updateError } = await supabase
+      .from('properties')
+      .update({
+        name: form.get('name') as string,
+        address_line1: form.get('address_line1') as string,
+        address_line2: (form.get('address_line2') as string) || null,
+        city: form.get('city') as string,
+        state: form.get('state') as string,
+        zip: form.get('zip') as string,
+        property_type: (form.get('property_type') as string) || null,
+        year_built: yearBuilt ? parseInt(yearBuilt, 10) : null,
+        notes: (form.get('notes') as string) || null,
+      })
+      .eq('id', property.id);
+
+    setLoading(false);
+
+    if (updateError) {
+      setError(updateError.message);
+      return;
+    }
+
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Pencil className="mr-2 h-3 w-3" />
+          Edit
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit Property</DialogTitle>
+          <DialogDescription>Update the property details.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="edit-name">Property Name</Label>
+            <Input id="edit-name" name="name" defaultValue={property.name} required />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-address">Address</Label>
+            <Input id="edit-address" name="address_line1" defaultValue={property.address_line1} required />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-address2">Address Line 2</Label>
+            <Input id="edit-address2" name="address_line2" defaultValue={property.address_line2 ?? ''} />
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="edit-city">City</Label>
+              <Input id="edit-city" name="city" defaultValue={property.city} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-state">State</Label>
+              <Input id="edit-state" name="state" defaultValue={property.state} maxLength={2} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-zip">ZIP</Label>
+              <Input id="edit-zip" name="zip" defaultValue={property.zip} required />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="edit-type">Property Type</Label>
+              <Input id="edit-type" name="property_type" defaultValue={property.property_type ?? ''} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-year">Year Built</Label>
+              <Input id="edit-year" name="year_built" type="number" defaultValue={property.year_built ?? ''} />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-notes">Notes</Label>
+            <Textarea id="edit-notes" name="notes" rows={2} defaultValue={property.notes ?? ''} />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button type="submit" disabled={loading}>{loading ? 'Saving...' : 'Save Changes'}</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+**Step 4: Create the DeletePropertyDialog**
+
+Create `apps/web/src/app/(dashboard)/properties/[id]/delete-property-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle, DialogTrigger,
+} from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Trash2 } from 'lucide-react';
+
+interface DeletePropertyDialogProps {
+  propertyId: string;
+  propertyName: string;
+}
+
+export function DeletePropertyDialog({ propertyId, propertyName }: DeletePropertyDialogProps) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    setError(null);
+    setLoading(true);
+
+    const { error: deleteError } = await supabase
+      .from('properties')
+      .delete()
+      .eq('id', propertyId);
+
+    setLoading(false);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      return;
+    }
+
+    router.push('/properties');
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="text-destructive hover:text-destructive">
+          <Trash2 className="mr-2 h-3 w-3" />
+          Delete
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Property</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete <strong>{propertyName}</strong>? This will also delete all units within this property. This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={loading}>
+            {loading ? 'Deleting...' : 'Delete Property'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+**Step 5: Verify build**
+
+```bash
+cd apps/web && pnpm build
+```
+
+Note: Build will fail because `UnitsTab` and `LeasesTab` are imported but don't exist yet. Create stub files first:
+
+Create `apps/web/src/app/(dashboard)/properties/[id]/units-tab.tsx`:
+
+```tsx
+'use client';
+
+export function UnitsTab({ propertyId, units }: { propertyId: string; units: any[] }) {
+  return <p className="text-muted-foreground">Units tab — coming next.</p>;
+}
+```
+
+Create `apps/web/src/app/(dashboard)/properties/[id]/leases-tab.tsx`:
+
+```tsx
+'use client';
+
+export function LeasesTab({ propertyId, units }: { propertyId: string; units: any[] }) {
+  return <p className="text-muted-foreground">Leases tab — coming next.</p>;
+}
+```
+
+Then build:
+
+```bash
+cd apps/web && pnpm build
+```
+
+Expected: Build succeeds.
+
+**Step 6: Commit**
+
+```bash
+git add apps/web/src/app/\(dashboard\)/properties/\[id\]/
+git commit -m "feat: add property detail page with overview, edit, and delete"
+```
+
+---
+
+### Task 5: Units Tab — List, Add, Edit, Delete
+
+**Files:**
+- Modify: `apps/web/src/app/(dashboard)/properties/[id]/units-tab.tsx` (replace stub)
+- Create: `apps/web/src/app/(dashboard)/properties/[id]/add-unit-dialog.tsx`
+- Create: `apps/web/src/app/(dashboard)/properties/[id]/edit-unit-dialog.tsx`
+
+**Context:**
+- Units table has: `unit_number`, `bedrooms`, `bathrooms`, `square_feet`, `rent_amount`, `is_available`, `notes`
+- Units are displayed in a table with row action dropdowns (edit, delete)
+- Delete is inline (no separate dialog — use a confirm in the dropdown or a small dialog)
+- Unit delete will fail with a DB error if the unit has leases (ON DELETE RESTRICT). Show the error message.
+
+**Step 1: Create AddUnitDialog**
+
+Create `apps/web/src/app/(dashboard)/properties/[id]/add-unit-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle, DialogTrigger,
+} from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Plus } from 'lucide-react';
+
+interface AddUnitDialogProps {
+  propertyId: string;
+}
+
+export function AddUnitDialog({ propertyId }: AddUnitDialogProps) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const form = new FormData(e.currentTarget);
+    const bedrooms = form.get('bedrooms') as string;
+    const bathrooms = form.get('bathrooms') as string;
+    const sqft = form.get('square_feet') as string;
+    const rent = form.get('rent_amount') as string;
+
+    const { error: insertError } = await supabase.from('units').insert({
+      property_id: propertyId,
+      unit_number: (form.get('unit_number') as string) || null,
+      bedrooms: bedrooms ? parseFloat(bedrooms) : null,
+      bathrooms: bathrooms ? parseFloat(bathrooms) : null,
+      square_feet: sqft ? parseInt(sqft, 10) : null,
+      rent_amount: rent ? parseFloat(rent) : null,
+      is_available: true,
+      notes: (form.get('notes') as string) || null,
+    });
+
+    setLoading(false);
+
+    if (insertError) {
+      setError(insertError.message);
+      return;
+    }
+
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
+          Add Unit
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Unit</DialogTitle>
+          <DialogDescription>Add a new unit to this property.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="unit_number">Unit Number</Label>
+            <Input id="unit_number" name="unit_number" placeholder="e.g. 101, A" />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="bedrooms">Bedrooms</Label>
+              <Input id="bedrooms" name="bedrooms" type="number" step="0.5" min="0" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="bathrooms">Bathrooms</Label>
+              <Input id="bathrooms" name="bathrooms" type="number" step="0.5" min="0" />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="square_feet">Sq Ft</Label>
+              <Input id="square_feet" name="square_feet" type="number" min="0" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rent_amount">Asking Rent ($)</Label>
+              <Input id="rent_amount" name="rent_amount" type="number" step="0.01" min="0" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="unit-notes">Notes</Label>
+            <Textarea id="unit-notes" name="notes" rows={2} />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button type="submit" disabled={loading}>{loading ? 'Saving...' : 'Add Unit'}</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+**Step 2: Create EditUnitDialog**
+
+Create `apps/web/src/app/(dashboard)/properties/[id]/edit-unit-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface EditUnitDialogProps {
+  unit: {
+    id: string;
+    unit_number?: string | null;
+    bedrooms?: number | null;
+    bathrooms?: number | null;
+    square_feet?: number | null;
+    rent_amount?: number | null;
+    notes?: string | null;
+  };
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EditUnitDialog({ unit, open, onOpenChange }: EditUnitDialogProps) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const form = new FormData(e.currentTarget);
+    const bedrooms = form.get('bedrooms') as string;
+    const bathrooms = form.get('bathrooms') as string;
+    const sqft = form.get('square_feet') as string;
+    const rent = form.get('rent_amount') as string;
+
+    const { error: updateError } = await supabase
+      .from('units')
+      .update({
+        unit_number: (form.get('unit_number') as string) || null,
+        bedrooms: bedrooms ? parseFloat(bedrooms) : null,
+        bathrooms: bathrooms ? parseFloat(bathrooms) : null,
+        square_feet: sqft ? parseInt(sqft, 10) : null,
+        rent_amount: rent ? parseFloat(rent) : null,
+        notes: (form.get('notes') as string) || null,
+      })
+      .eq('id', unit.id);
+
+    setLoading(false);
+
+    if (updateError) {
+      setError(updateError.message);
+      return;
+    }
+
+    onOpenChange(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Unit {unit.unit_number ?? ''}</DialogTitle>
+          <DialogDescription>Update unit details.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="eu-unit_number">Unit Number</Label>
+            <Input id="eu-unit_number" name="unit_number" defaultValue={unit.unit_number ?? ''} />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="eu-bedrooms">Bedrooms</Label>
+              <Input id="eu-bedrooms" name="bedrooms" type="number" step="0.5" min="0" defaultValue={unit.bedrooms ?? ''} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="eu-bathrooms">Bathrooms</Label>
+              <Input id="eu-bathrooms" name="bathrooms" type="number" step="0.5" min="0" defaultValue={unit.bathrooms ?? ''} />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="eu-sqft">Sq Ft</Label>
+              <Input id="eu-sqft" name="square_feet" type="number" min="0" defaultValue={unit.square_feet ?? ''} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="eu-rent">Asking Rent ($)</Label>
+              <Input id="eu-rent" name="rent_amount" type="number" step="0.01" min="0" defaultValue={unit.rent_amount ?? ''} />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="eu-notes">Notes</Label>
+            <Textarea id="eu-notes" name="notes" rows={2} defaultValue={unit.notes ?? ''} />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+            <Button type="submit" disabled={loading}>{loading ? 'Saving...' : 'Save Changes'}</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+**Step 3: Replace the UnitsTab stub**
+
+Replace `apps/web/src/app/(dashboard)/properties/[id]/units-tab.tsx` with:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import { AddUnitDialog } from './add-unit-dialog';
+import { EditUnitDialog } from './edit-unit-dialog';
+
+interface Unit {
+  id: string;
+  unit_number?: string | null;
+  bedrooms?: number | null;
+  bathrooms?: number | null;
+  square_feet?: number | null;
+  rent_amount?: number | null;
+  is_available?: boolean;
+  notes?: string | null;
+  leases?: { id: string; status: string }[];
+}
+
+interface UnitsTabProps {
+  propertyId: string;
+  units: Unit[];
+}
+
+export function UnitsTab({ propertyId, units }: UnitsTabProps) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [editingUnit, setEditingUnit] = useState<Unit | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete(unitId: string) {
+    setError(null);
+    const { error: deleteError } = await supabase
+      .from('units')
+      .delete()
+      .eq('id', unitId);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <AddUnitDialog propertyId={propertyId} />
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {units.length === 0 ? (
+        <p className="py-8 text-center text-muted-foreground">No units yet. Add your first unit.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Unit</TableHead>
+              <TableHead>Bed / Bath</TableHead>
+              <TableHead>Sq Ft</TableHead>
+              <TableHead>Rent</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="w-10" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {units.map((unit) => {
+              const hasActiveLease = unit.leases?.some((l) => l.status === 'active');
+              return (
+                <TableRow key={unit.id}>
+                  <TableCell className="font-medium">{unit.unit_number ?? '—'}</TableCell>
+                  <TableCell>
+                    {unit.bedrooms ?? '—'} / {unit.bathrooms ?? '—'}
+                  </TableCell>
+                  <TableCell>{unit.square_feet?.toLocaleString() ?? '—'}</TableCell>
+                  <TableCell>{unit.rent_amount ? `$${unit.rent_amount.toLocaleString()}` : '—'}</TableCell>
+                  <TableCell>
+                    {hasActiveLease ? (
+                      <Badge>Occupied</Badge>
+                    ) : (
+                      <Badge variant="secondary">Available</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon" className="h-8 w-8">
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => setEditingUnit(unit)}>
+                          <Pencil className="mr-2 h-4 w-4" />
+                          Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => handleDelete(unit.id)}
+                          className="text-destructive focus:text-destructive"
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+
+      {editingUnit && (
+        <EditUnitDialog
+          unit={editingUnit}
+          open={!!editingUnit}
+          onOpenChange={(open) => { if (!open) setEditingUnit(null); }}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+**Step 4: Verify build**
+
+```bash
+cd apps/web && pnpm build
+```
+
+Expected: Build succeeds.
+
+**Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(dashboard\)/properties/\[id\]/
+git commit -m "feat: add units tab with CRUD (add, edit, delete via table + modals)"
+```
+
+---
+
+### Task 6: Leases Tab — List, Create with Tenant Invite, Terminate
+
+**Files:**
+- Modify: `apps/web/src/app/(dashboard)/properties/[id]/leases-tab.tsx` (replace stub)
+- Create: `apps/web/src/app/(dashboard)/properties/[id]/create-lease-dialog.tsx`
+
+**Context:**
+- Lease creation modal has 3 sections: unit + rent terms, late fee config, tenant email(s)
+- Saves lease as `draft`, then calls `invite-tenant` Edge Function for each tenant email
+- The `invite-tenant` Edge Function URL: `${NEXT_PUBLIC_SUPABASE_URL}/functions/v1/invite-tenant`
+- It requires a Bearer token (user's access token) and body: `{ lease_id, email, is_primary }`
+- Lease list shows unit, status, rent, dates, and tenant info
+- Row actions: Terminate (for active leases), Delete (for draft leases)
+
+**Step 1: Create the CreateLeaseDialog**
+
+Create `apps/web/src/app/(dashboard)/properties/[id]/create-lease-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle, DialogTrigger,
+} from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Plus, X } from 'lucide-react';
+
+interface Unit {
+  id: string;
+  unit_number?: string | null;
+  rent_amount?: number | null;
+  leases?: { id: string; status: string }[];
+}
+
+interface CreateLeaseDialogProps {
+  units: Unit[];
+}
+
+export function CreateLeaseDialog({ units }: CreateLeaseDialogProps) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [unitId, setUnitId] = useState('');
+  const [lateFeeType, setLateFeeType] = useState('flat');
+  const [tenantEmails, setTenantEmails] = useState<string[]>(['']);
+
+  // Only show units without active leases
+  const availableUnits = units.filter(
+    (u) => !u.leases?.some((l) => l.status === 'active'),
+  );
+
+  function addTenantField() {
+    setTenantEmails([...tenantEmails, '']);
+  }
+
+  function removeTenantField(index: number) {
+    setTenantEmails(tenantEmails.filter((_, i) => i !== index));
+  }
+
+  function updateTenantEmail(index: number, value: string) {
+    const updated = [...tenantEmails];
+    updated[index] = value;
+    setTenantEmails(updated);
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const form = new FormData(e.currentTarget);
+    const lateFeeAmount = form.get('late_fee_amount') as string;
+    const securityDeposit = form.get('security_deposit') as string;
+
+    // 1. Create the lease
+    const { data: lease, error: leaseError } = await supabase
+      .from('leases')
+      .insert({
+        unit_id: unitId,
+        status: 'draft',
+        start_date: form.get('start_date') as string,
+        end_date: (form.get('end_date') as string) || null,
+        rent_amount: parseFloat(form.get('rent_amount') as string),
+        security_deposit: securityDeposit ? parseFloat(securityDeposit) : null,
+        rent_due_day: parseInt(form.get('rent_due_day') as string, 10),
+        grace_period_days: parseInt(form.get('grace_period_days') as string, 10),
+        late_fee_type: lateFeeType as 'flat' | 'percentage',
+        late_fee_amount: lateFeeAmount ? parseFloat(lateFeeAmount) : null,
+        notes: (form.get('notes') as string) || null,
+      })
+      .select('id')
+      .single();
+
+    if (leaseError) {
+      setError(leaseError.message);
+      setLoading(false);
+      return;
+    }
+
+    // 2. Invite tenants via Edge Function
+    const validEmails = tenantEmails.filter((e) => e.trim());
+    const { data: { session } } = await supabase.auth.getSession();
+
+    for (let i = 0; i < validEmails.length; i++) {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/invite-tenant`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session?.access_token}`,
+          },
+          body: JSON.stringify({
+            lease_id: lease!.id,
+            email: validEmails[i].trim(),
+            is_primary: i === 0,
+          }),
+        },
+      );
+
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({ error: 'Failed to invite tenant' }));
+        setError(`Lease created but tenant invite failed for ${validEmails[i]}: ${errData.error}`);
+        setLoading(false);
+        router.refresh();
+        return;
+      }
+    }
+
+    setLoading(false);
+    setOpen(false);
+    setUnitId('');
+    setTenantEmails(['']);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) { setError(null); setUnitId(''); setTenantEmails(['']); } }}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
+          Create Lease
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create Lease</DialogTitle>
+          <DialogDescription>Set up a new lease and invite tenants.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {/* Section 1: Unit & Rent Terms */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">Unit & Rent</h3>
+            <div className="space-y-2">
+              <Label>Unit</Label>
+              <Select value={unitId} onValueChange={setUnitId} required>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a unit" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableUnits.map((u) => (
+                    <SelectItem key={u.id} value={u.id}>
+                      {u.unit_number ?? 'Unit'}{u.rent_amount ? ` — $${u.rent_amount}/mo` : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {availableUnits.length === 0 && (
+                <p className="text-xs text-muted-foreground">No available units. All units have active leases.</p>
+              )}
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="rent_amount">Monthly Rent ($)</Label>
+                <Input id="rent_amount" name="rent_amount" type="number" step="0.01" min="0.01" required
+                  defaultValue={availableUnits.find((u) => u.id === unitId)?.rent_amount ?? ''} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="security_deposit">Security Deposit ($)</Label>
+                <Input id="security_deposit" name="security_deposit" type="number" step="0.01" min="0" />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="start_date">Start Date</Label>
+                <Input id="start_date" name="start_date" type="date" required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="end_date">End Date</Label>
+                <Input id="end_date" name="end_date" type="date" />
+              </div>
+            </div>
+          </div>
+
+          {/* Section 2: Late Fee Config */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">Late Fee Settings</h3>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="rent_due_day">Due Day (1-28)</Label>
+                <Input id="rent_due_day" name="rent_due_day" type="number" min="1" max="28" defaultValue="1" required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="grace_period_days">Grace Days</Label>
+                <Input id="grace_period_days" name="grace_period_days" type="number" min="0" max="30" defaultValue="5" required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="late_fee_amount">Late Fee</Label>
+                <Input id="late_fee_amount" name="late_fee_amount" type="number" step="0.01" min="0" />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Late Fee Type</Label>
+              <Select value={lateFeeType} onValueChange={setLateFeeType}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="flat">Flat ($)</SelectItem>
+                  <SelectItem value="percentage">Percentage (%)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Section 3: Tenants */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">Tenants</h3>
+            {tenantEmails.map((email, i) => (
+              <div key={i} className="flex gap-2">
+                <div className="flex-1 space-y-1">
+                  <Input
+                    type="email"
+                    placeholder="tenant@example.com"
+                    value={email}
+                    onChange={(e) => updateTenantEmail(i, e.target.value)}
+                  />
+                  {i === 0 && <p className="text-xs text-muted-foreground">Primary tenant</p>}
+                </div>
+                {tenantEmails.length > 1 && (
+                  <Button type="button" variant="ghost" size="icon" onClick={() => removeTenantField(i)}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            ))}
+            <Button type="button" variant="outline" size="sm" onClick={addTenantField}>
+              <Plus className="mr-2 h-3 w-3" />
+              Add Another Tenant
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="lease-notes">Notes</Label>
+            <Textarea id="lease-notes" name="notes" rows={2} />
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button type="submit" disabled={loading || !unitId}>
+              {loading ? 'Creating...' : 'Create Lease'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+**Step 2: Replace the LeasesTab stub**
+
+Replace `apps/web/src/app/(dashboard)/properties/[id]/leases-tab.tsx` with:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { MoreHorizontal, Ban, Trash2 } from 'lucide-react';
+import { CreateLeaseDialog } from './create-lease-dialog';
+
+interface LeaseTenant {
+  id: string;
+  user_id: string;
+  is_primary: boolean;
+  accepted_at?: string | null;
+}
+
+interface Lease {
+  id: string;
+  status: string;
+  start_date: string;
+  end_date?: string | null;
+  rent_amount: number;
+  rent_due_day: number;
+  lease_tenants?: LeaseTenant[];
+}
+
+interface Unit {
+  id: string;
+  unit_number?: string | null;
+  rent_amount?: number | null;
+  leases?: Lease[];
+}
+
+interface LeasesTabProps {
+  propertyId: string;
+  units: Unit[];
+}
+
+const statusVariant: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  active: 'default',
+  draft: 'secondary',
+  expired: 'outline',
+  terminated: 'destructive',
+};
+
+export function LeasesTab({ propertyId, units }: LeasesTabProps) {
+  const router = useRouter();
+  const supabase = getSupabaseBrowserClient();
+  const [error, setError] = useState<string | null>(null);
+
+  // Flatten leases from all units, attaching unit info
+  const allLeases = units.flatMap((unit) =>
+    (unit.leases ?? []).map((lease) => ({
+      ...lease,
+      unitNumber: unit.unit_number,
+      unitId: unit.id,
+    })),
+  );
+
+  async function handleTerminate(leaseId: string) {
+    setError(null);
+    const { error: updateError } = await supabase
+      .from('leases')
+      .update({ status: 'terminated' })
+      .eq('id', leaseId);
+
+    if (updateError) {
+      setError(updateError.message);
+      return;
+    }
+    router.refresh();
+  }
+
+  async function handleDelete(leaseId: string) {
+    setError(null);
+    const { error: deleteError } = await supabase
+      .from('leases')
+      .delete()
+      .eq('id', leaseId);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <CreateLeaseDialog units={units} />
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {allLeases.length === 0 ? (
+        <p className="py-8 text-center text-muted-foreground">No leases yet. Create your first lease.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Unit</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Rent</TableHead>
+              <TableHead>Start</TableHead>
+              <TableHead>End</TableHead>
+              <TableHead>Tenants</TableHead>
+              <TableHead className="w-10" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {allLeases.map((lease) => (
+              <TableRow key={lease.id}>
+                <TableCell className="font-medium">{lease.unitNumber ?? '—'}</TableCell>
+                <TableCell>
+                  <Badge variant={statusVariant[lease.status] ?? 'secondary'} className="capitalize">
+                    {lease.status}
+                  </Badge>
+                </TableCell>
+                <TableCell>${lease.rent_amount.toLocaleString()}/mo</TableCell>
+                <TableCell>{lease.start_date}</TableCell>
+                <TableCell>{lease.end_date ?? 'Month-to-month'}</TableCell>
+                <TableCell>
+                  {(lease.lease_tenants?.length ?? 0) === 0 ? (
+                    <span className="text-muted-foreground">None</span>
+                  ) : (
+                    <span>
+                      {lease.lease_tenants!.length} tenant{lease.lease_tenants!.length !== 1 ? 's' : ''}
+                      {lease.lease_tenants!.some((t) => !t.accepted_at) && (
+                        <span className="ml-1 text-xs text-muted-foreground">(pending)</span>
+                      )}
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {lease.status === 'active' && (
+                        <DropdownMenuItem
+                          onClick={() => handleTerminate(lease.id)}
+                          className="text-destructive focus:text-destructive"
+                        >
+                          <Ban className="mr-2 h-4 w-4" />
+                          Terminate
+                        </DropdownMenuItem>
+                      )}
+                      {lease.status === 'draft' && (
+                        <DropdownMenuItem
+                          onClick={() => handleDelete(lease.id)}
+                          className="text-destructive focus:text-destructive"
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}
+```
+
+**Step 3: Verify build**
+
+```bash
+cd apps/web && pnpm build
+```
+
+Expected: Build succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/app/\(dashboard\)/properties/\[id\]/
+git commit -m "feat: add leases tab with create (+ tenant invite) and terminate/delete"
+```
+
+---
+
+### Task 7: Final Verification
+
+**Step 1: Full typecheck**
+
+```bash
+pnpm turbo typecheck
+```
+
+Expected: All packages pass.
+
+**Step 2: Full build**
+
+```bash
+cd apps/web && pnpm build
+```
+
+Expected: Build succeeds.
+
+**Step 3: Run existing tests**
+
+```bash
+pnpm turbo test:unit
+```
+
+Expected: All tests pass (no regressions).
+
+**Step 4: Final commit if any adjustments were needed**
+
+Fix any issues, commit, push, and create PR.


### PR DESCRIPTION
## Summary
- Property list page with responsive card grid showing unit/lease counts
- Property detail page with tabbed navigation (Overview, Units, Leases)
- Property CRUD: add, edit, delete with modal dialogs
- Unit CRUD: table display with add/edit/delete via modals and dropdown actions
- Lease creation with multi-section modal (unit + rent terms, late fee config, tenant email invites)
- Lease management: terminate active leases, delete draft leases
- 6 new shadcn/ui components installed (table, dialog, select, tabs, textarea, dropdown-menu)
- Sidebar navigation updated with Properties link

## Test plan
- [x] `pnpm turbo typecheck` — 6 packages pass
- [x] `pnpm turbo test:unit` — 12 tests pass, no regressions
- [ ] Manual: create property, add units, create lease with tenant invite
- [ ] Manual: edit/delete property, edit/delete unit, terminate lease

🤖 Generated with [Claude Code](https://claude.com/claude-code)